### PR TITLE
Update to JupyterLab 3 prebuilt extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example repository to create an environment with course materials in Python.
 
 ## Try it on Binder
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plasmabio/materials-example/master?urlpath=%2Flab/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plasmabio/template-python/master?urlpath=%2Flab/)
 
 ## Structure of the repo
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,7 +12,10 @@ dependencies:
   - numpy
   - pandas
   - matplotlib
+  - ipywidgets>=7.6,<8
   - jupyterlab>=3
+  - jupyterlab-topbar
+  - jupyterlab-system-monitor
   - nodejs
   - nbresuse
   - psutil

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,9 +13,8 @@ dependencies:
   - pandas
   - matplotlib
   - ipywidgets>=7.6,<8
-  - jupyterlab>=3
+  - jupyterlab>=3,<4
+  - jupyter-resource-usage
   - jupyterlab-topbar
   - jupyterlab-system-monitor
   - nodejs
-  - nbresuse
-  - psutil

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pandas
   - matplotlib
   - ipywidgets>=7.6,<8
-  - jupyterlab>=3,<4
+  - jupyterlab>=3.2,<4
   - jupyter-resource-usage
   - jupyterlab-topbar
   - jupyterlab-system-monitor

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,0 @@
-jupyter labextension install \
-  @jupyter-widgets/jupyterlab-manager \
-  jupyterlab-topbar-extension \
-  jupyterlab-system-monitor \
-  jupyterlab-topbar-text
-  


### PR DESCRIPTION
JupyterLab 3 now supports the prebuilt extension system, which do not require nodejs or installing via `jupyter labextension install` for most extensions.

This makes creating new images much faster.

Testing with: https://mybinder.org/v2/gh/jtpio/plasmabio-template-python/update-binder?urlpath=%2Flab/