### PR TITLE
Add `jupyterlab-topbar-text` to `environment.yml`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,5 +16,6 @@ dependencies:
   - jupyterlab>=3.2,<4
   - jupyter-resource-usage
   - jupyterlab-topbar
+  - jupyterlab-topbar-text
   - jupyterlab-system-monitor
   - nodejs


### PR DESCRIPTION
Keeping as a draft while waiting for https://github.com/conda-forge/staged-recipes/pull/17189 to be merged

Testing with https://mybinder.org/v2/gh/jtpio/plasmabio-template-python/jupyterlab-topbar-text?urlpath=%2Flab/