### PR TITLE
Stick to JupyterHub 1.x for now

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pandas
   - matplotlib
   - ipywidgets>=7.6,<8
+  - jupyterhub>=1.5,<2
   - jupyterlab>=3.2,<4
   - jupyter-resource-usage
   - jupyterlab-topbar


### PR DESCRIPTION
Since TLJH is still on JupyterHub 1.x for now:

https://github.com/jupyterhub/the-littlest-jupyterhub/blob/0572976d25c18bc88d936f8bd8627bbfed069b53/tljh/installer.py#L124

We should also ensure this is the case in the user images for consistency,